### PR TITLE
Finance: Category drill-down /finance/category/[name]

### DIFF
--- a/web/src/app/finance/budget/page.tsx
+++ b/web/src/app/finance/budget/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { getCategorySpending, getCategories } from "@/lib/finance-queries";
 import { formatCurrency } from "@/lib/utils";
 import { Card } from "@/components/finance/Card";
@@ -74,7 +75,12 @@ export default async function BudgetPage() {
               <div className="flex items-center justify-between text-sm">
                 <div className="flex items-center gap-2">
                   <span>{overBudget ? "🔴" : noBudget ? "⚪" : "✅"}</span>
-                  <span className="font-medium">{item.category}</span>
+                  <Link
+                    href={`/finance/category/${encodeURIComponent(item.category)}`}
+                    className="font-medium hover:text-indigo-300 transition-colors"
+                  >
+                    {item.category}
+                  </Link>
                   <span className="text-zinc-500 text-xs">({item.group})</span>
                   <span className="opacity-0 group-hover:opacity-100 transition-opacity">
                     <CommentButton description={item.category} amount={formatCurrency(item.actual)} category={item.category} page="budget" />

--- a/web/src/app/finance/category/[name]/page.tsx
+++ b/web/src/app/finance/category/[name]/page.tsx
@@ -1,0 +1,140 @@
+import { getCategoryDetail } from "@/lib/finance-queries";
+import { formatCurrency, formatDate } from "@/lib/utils";
+import { Card } from "@/components/finance/Card";
+import { SpendBarChart } from "@/components/finance/Charts";
+
+export const dynamic = "force-dynamic";
+
+type CategoryTransaction = {
+  transaction_id: string;
+  date?: string | Date;
+  description?: string;
+  amount: number;
+};
+
+type CategoryMonthly = {
+  month: string;
+  total: number;
+  count: number;
+};
+
+type MerchantRow = {
+  _id: string;
+  total: number;
+  count: number;
+};
+
+type CategoryDetail = {
+  transactions: CategoryTransaction[];
+  monthlyTrend: CategoryMonthly[];
+  topMerchants: MerchantRow[];
+  stats: {
+    avgMonthly: number;
+    totalAllTime: number;
+    transactionCount: number;
+    maxSingle: number;
+  };
+};
+
+function formatMonthLabel(key: string) {
+  const [year, month] = key.split("-").map(Number);
+  if (!year || !month) return key;
+  const date = new Date(year, month - 1, 1);
+  return date.toLocaleDateString("en-US", { month: "short", year: "2-digit" });
+}
+
+export default async function CategoryDetailPage({ params }: { params: { name: string } }) {
+  const decodedName = decodeURIComponent(params.name);
+  const detail = await getCategoryDetail(decodedName, 12) as unknown as CategoryDetail;
+
+  const chartData = detail.monthlyTrend.map((m) => ({
+    label: formatMonthLabel(m.month),
+    total: m.total,
+  }));
+  const recentTransactions = detail.transactions.slice(0, 50);
+  const maxMerchantTotal = detail.topMerchants[0]?.total || 1;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">{decodedName}</h1>
+        <p className="text-zinc-500 text-sm">Category drill-down • last 12 months</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Card title="Avg Monthly" value={formatCurrency(detail.stats.avgMonthly)} subtitle="Last 12 months" />
+        <Card title="Total All Time" value={formatCurrency(detail.stats.totalAllTime)} subtitle="All-time spend" />
+        <Card title="Transactions" value={detail.stats.transactionCount.toLocaleString()} subtitle="All time" />
+        <Card title="Largest Single" value={formatCurrency(detail.stats.maxSingle)} subtitle="Largest charge" className="border-red-500/30" />
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <div className="bg-[#141420] border border-[#27272a] rounded-xl p-5">
+          <h2 className="text-lg font-semibold mb-4">Monthly Spend</h2>
+          <SpendBarChart data={chartData} />
+        </div>
+
+        <div className="bg-[#141420] border border-[#27272a] rounded-xl p-5">
+          <h2 className="text-lg font-semibold mb-4">Top Merchants</h2>
+          <div className="space-y-2">
+            {detail.topMerchants.length === 0 && (
+              <p className="text-sm text-zinc-500">No merchant data found.</p>
+            )}
+            {detail.topMerchants.map((m) => {
+              const pct = (m.total / maxMerchantTotal) * 100;
+              return (
+                <div key={m._id} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="truncate max-w-xs">{m._id || "Unknown"}</span>
+                    <span className="text-zinc-400 ml-2 whitespace-nowrap">
+                      {formatCurrency(m.total)} ({m.count}x)
+                    </span>
+                  </div>
+                  <div className="h-1.5 bg-zinc-800 rounded-full">
+                    <div className="h-full bg-indigo-500 rounded-full" style={{ width: `${pct}%` }} />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-[#141420] border border-[#27272a] rounded-xl overflow-hidden">
+        <div className="flex items-center justify-between px-5 py-4">
+          <h2 className="text-lg font-semibold">Recent Transactions</h2>
+          <span className="text-xs text-zinc-500">Last {recentTransactions.length} transactions</span>
+        </div>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-zinc-500 text-left bg-zinc-900/50">
+              <th className="px-4 py-3 font-medium">Date</th>
+              <th className="px-4 py-3 font-medium">Description</th>
+              <th className="px-4 py-3 font-medium text-right">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {recentTransactions.length === 0 && (
+              <tr>
+                <td colSpan={3} className="px-4 py-6 text-center text-zinc-500">
+                  No transactions found for this category.
+                </td>
+              </tr>
+            )}
+            {recentTransactions.map((t) => (
+              <tr key={t.transaction_id} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
+                <td className="px-4 py-2 text-zinc-400 whitespace-nowrap">
+                  {t.date ? formatDate(t.date) : "-"}
+                </td>
+                <td className="px-4 py-2 max-w-md truncate">{t.description}</td>
+                <td className="px-4 py-2 text-right font-mono text-red-400">
+                  {formatCurrency(t.amount)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/finance/insights/page.tsx
+++ b/web/src/app/finance/insights/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { getInsightsData } from "@/lib/finance-queries";
 import { formatCurrency } from "@/lib/utils";
 import { DowChart } from "@/components/finance/Charts";
@@ -82,7 +83,14 @@ export default async function InsightsPage() {
           <tbody>
             {catTotals.map(({ cat, total }) => (
               <tr key={cat} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
-                <td className="py-2 font-medium">{cat}</td>
+                <td className="py-2 font-medium">
+                  <Link
+                    href={`/finance/category/${encodeURIComponent(cat)}`}
+                    className="hover:text-indigo-300 transition-colors"
+                  >
+                    {cat}
+                  </Link>
+                </td>
                 {trendMonths.map((m) => (
                   <td key={m} className="py-2 text-right text-zinc-400 px-3">
                     {trendCategories[cat][m] ? formatCurrency(trendCategories[cat][m]) : "-"}

--- a/web/src/components/finance/Charts.tsx
+++ b/web/src/components/finance/Charts.tsx
@@ -11,6 +11,7 @@ type MonthlyBarDatum = { _id: string; income: number; expenses: number };
 type CategoryDatum = { _id: string; total: number };
 type NetWorthDatum = { month: string; net: number };
 type DowDatum = { _id: number | string; total: number; count: number };
+type SpendMonthDatum = { label: string; total: number };
 
 export function MonthlyBarChart({ data }: { data: MonthlyBarDatum[] }) {
   return (
@@ -70,6 +71,19 @@ export function DowChart({ data }: { data: DowDatum[] }) {
         <YAxis stroke="#71717a" fontSize={12} tickFormatter={(v) => `$${v.toFixed(0)}`} />
         <Tooltip contentStyle={tooltipStyle} formatter={(v: unknown) => formatCurrency(Number(v))} />
         <Bar dataKey="avg" name="Avg Spend" fill="#8b5cf6" radius={[4,4,0,0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function SpendBarChart({ data }: { data: SpendMonthDatum[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data}>
+        <XAxis dataKey="label" stroke="#71717a" fontSize={12} />
+        <YAxis stroke="#71717a" fontSize={12} tickFormatter={(v) => `$${(v / 1000).toFixed(0)}k`} />
+        <Tooltip contentStyle={tooltipStyle} formatter={(v: unknown) => formatCurrency(Number(v))} />
+        <Bar dataKey="total" name="Spend" fill="#ef4444" radius={[4, 4, 0, 0]} />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/web/src/components/finance/Nav.tsx
+++ b/web/src/components/finance/Nav.tsx
@@ -66,7 +66,18 @@ export function Nav() {
     return () => { document.body.style.overflow = ""; };
   }, [open]);
 
-  const currentPage = allLinks.find((l) => l.href === pathname);
+  const categoryMatch = pathname?.match(/^\/finance\/category\/(.+)$/);
+  let categoryLabel = "";
+  if (categoryMatch?.[1]) {
+    try {
+      categoryLabel = decodeURIComponent(categoryMatch[1]);
+    } catch {
+      categoryLabel = categoryMatch[1];
+    }
+  }
+  const currentPage = allLinks.find((l) => l.href === pathname) || (
+    categoryLabel ? { href: pathname, label: `Category: ${categoryLabel}`, icon: "🏷️" } : undefined
+  );
 
   return (
     <>

--- a/web/src/lib/finance-queries.ts
+++ b/web/src/lib/finance-queries.ts
@@ -40,6 +40,71 @@ export async function getCategorySpending(year?: number, month?: number) {
   return db.collection("transactions").aggregate(pipeline).toArray();
 }
 
+export async function getCategoryDetail(name: string, months = 12) {
+  const db = await getDb();
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth() - months + 1, 1);
+
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const categoryRegex = new RegExp(`^${escaped}$`, "i");
+  const baseMatch = { amount: { $lt: 0 }, category: { $regex: categoryRegex } };
+
+  const [transactions, monthlyRaw, topMerchants, statsRaw] = await Promise.all([
+    db.collection("transactions").find(baseMatch).sort({ date: -1 }).limit(100).toArray(),
+    db.collection("transactions").aggregate([
+      { $match: { ...baseMatch, date: { $gte: start } } },
+      { $addFields: { monthKey: { $dateToString: { format: "%Y-%m", date: "$date" } } } },
+      { $group: { _id: "$monthKey", total: { $sum: { $abs: "$amount" } }, count: { $sum: 1 } } },
+      { $sort: { _id: 1 } },
+    ]).toArray(),
+    db.collection("transactions").aggregate([
+      { $match: baseMatch },
+      { $group: { _id: "$description", total: { $sum: { $abs: "$amount" } }, count: { $sum: 1 } } },
+      { $sort: { total: -1 } },
+      { $limit: 10 },
+    ]).toArray(),
+    db.collection("transactions").aggregate([
+      { $match: baseMatch },
+      {
+        $group: {
+          _id: null,
+          total: { $sum: { $abs: "$amount" } },
+          count: { $sum: 1 },
+          maxSingle: { $max: { $abs: "$amount" } },
+        },
+      },
+    ]).toArray(),
+  ]);
+
+  const monthSlots = Array.from({ length: months }, (_, i) => {
+    const d = new Date(now.getFullYear(), now.getMonth() - (months - 1 - i), 1);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  });
+  const monthlyMap: Record<string, { total: number; count: number }> = {};
+  (monthlyRaw as Array<{ _id: string; total: number; count: number }>).forEach((row) => {
+    monthlyMap[row._id] = { total: row.total, count: row.count };
+  });
+  const monthlyTrend = monthSlots.map((key) => ({
+    month: key,
+    total: monthlyMap[key]?.total || 0,
+    count: monthlyMap[key]?.count || 0,
+  }));
+
+  const totalAllTime = statsRaw[0]?.total || 0;
+  const transactionCount = statsRaw[0]?.count || 0;
+  const maxSingle = statsRaw[0]?.maxSingle || 0;
+  const avgMonthly = months > 0
+    ? monthlyTrend.reduce((s, m) => s + m.total, 0) / months
+    : 0;
+
+  return {
+    transactions,
+    monthlyTrend,
+    topMerchants,
+    stats: { avgMonthly, totalAllTime, transactionCount, maxSingle },
+  };
+}
+
 export async function getRecentTransactions(limit = 20) {
   const db = await getDb();
   return db.collection("transactions").find({ amount: { $ne: null } }).sort({ date: -1 }).limit(limit).toArray();


### PR DESCRIPTION
Closes #17

## What's in this PR

- **New route**: `/finance/category/[name]` — dynamic category detail page
- **getCategoryDetail()** query returns monthly trend (12m), top merchants, aggregate stats, and last 100 transactions
- **SpendBarChart** component added to Charts.tsx (reusable single-series bar chart)
- **Budget page**: category names are now clickable links to drill-down
- **Insights page**: category names in trend table link to drill-down  
- **Nav**: header breadcrumb recognizes /finance/category/* routes

## UI

- 4 stat cards: Avg Monthly, Total All Time, Transaction Count, Largest Single
- Monthly spend bar chart (12 months)
- Top 10 merchants with horizontal progress bars
- Recent transactions table (last 50)