### PR TITLE
Finance: Spending Anomaly Detector /finance/anomalies

### DIFF
--- a/web/src/app/finance/anomalies/page.tsx
+++ b/web/src/app/finance/anomalies/page.tsx
@@ -1,0 +1,170 @@
+import { getSpendingAnomalies } from "@/lib/finance-queries";
+import { formatCurrency, formatDate } from "@/lib/utils";
+import { Card } from "@/components/finance/Card";
+
+export const dynamic = "force-dynamic";
+
+type CategorySpike = {
+  category: string;
+  thisMonth: number;
+  avgPrior3: number;
+  ratio: number;
+  delta: number;
+};
+
+type LargeTransaction = {
+  date?: Date | string;
+  description: string;
+  category: string;
+  amount: number;
+  avgCategoryAmount: number;
+  ratio: number;
+};
+
+type NewMerchant = {
+  merchant: string;
+  total: number;
+  firstSeen?: Date | string;
+};
+
+function spikeColor(ratio: number): string {
+  if (ratio >= 2) return "text-red-400";
+  if (ratio >= 1.5) return "text-yellow-400";
+  return "text-orange-400";
+}
+
+export default async function SpendingAnomaliesPage() {
+  const { categorySpikes, largeTransactions, newMerchants, summary, thresholds } = await getSpendingAnomalies() as {
+    categorySpikes: CategorySpike[];
+    largeTransactions: LargeTransaction[];
+    newMerchants: NewMerchant[];
+    summary: { totalCategorySpikes: number; totalLargeTransactions: number; totalNewMerchants: number };
+    thresholds: { unknownCategoryAvg: number; newMerchantMinTotal: number };
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Spending Anomalies</h1>
+        <p className="text-zinc-400 text-sm mt-1">Unusual patterns detected this month</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <Card
+          title="Category Spikes"
+          value={`${summary.totalCategorySpikes}`}
+          subtitle="40%+ vs 3-mo avg"
+          className={summary.totalCategorySpikes > 0 ? "border-yellow-500/30" : ""}
+        />
+        <Card
+          title="Large Transactions"
+          value={`${summary.totalLargeTransactions}`}
+          subtitle="3x+ category avg"
+          className={summary.totalLargeTransactions > 0 ? "border-red-500/30" : ""}
+        />
+        <Card
+          title="New Merchants"
+          value={`${summary.totalNewMerchants}`}
+          subtitle={`First-time spend > ${formatCurrency(thresholds.newMerchantMinTotal)}`}
+          className={summary.totalNewMerchants > 0 ? "border-orange-500/30" : ""}
+        />
+      </div>
+
+      <div className="bg-[#141420] border border-[#27272a] rounded-xl p-5 overflow-x-auto">
+        <h2 className="text-lg font-semibold mb-4">Category Spikes</h2>
+        {categorySpikes.length === 0 ? (
+          <p className="text-zinc-500 text-sm">No category spikes detected this month.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-zinc-500 text-left border-b border-zinc-800">
+                <th className="pb-2 font-medium">Category</th>
+                <th className="pb-2 font-medium text-right">This Month</th>
+                <th className="pb-2 font-medium text-right">3-Mo Avg</th>
+                <th className="pb-2 font-medium text-right">Spike</th>
+              </tr>
+            </thead>
+            <tbody>
+              {categorySpikes.map((row, i) => (
+                <tr key={`${row.category}-${i}`} className="border-b border-zinc-800/40 hover:bg-zinc-800/20">
+                  <td className="py-2 font-medium text-zinc-200">{row.category}</td>
+                  <td className="py-2 text-right font-mono text-zinc-100">{formatCurrency(row.thisMonth)}</td>
+                  <td className="py-2 text-right font-mono text-zinc-400">
+                    {row.avgPrior3 > 0 ? formatCurrency(row.avgPrior3) : "—"}
+                  </td>
+                  <td className={`py-2 text-right font-mono font-semibold ${spikeColor(row.ratio)}`}>
+                    {row.ratio.toFixed(1)}x
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="bg-[#141420] border border-[#27272a] rounded-xl p-5 overflow-x-auto">
+        <h2 className="text-lg font-semibold mb-4">Large Transactions</h2>
+        {largeTransactions.length === 0 ? (
+          <p className="text-zinc-500 text-sm">No large transactions flagged this month.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-zinc-500 text-left border-b border-zinc-800">
+                <th className="pb-2 font-medium">Date</th>
+                <th className="pb-2 font-medium">Description</th>
+                <th className="pb-2 font-medium">Category</th>
+                <th className="pb-2 font-medium text-right">Amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              {largeTransactions.map((tx, i) => {
+                const note = tx.avgCategoryAmount > 0
+                  ? `(${tx.ratio.toFixed(1)}x avg)`
+                  : `(>${formatCurrency(thresholds.unknownCategoryAvg)})`;
+                return (
+                  <tr key={`${tx.description}-${i}`} className="border-b border-zinc-800/40 hover:bg-zinc-800/20">
+                    <td className="py-2 text-zinc-400 font-mono whitespace-nowrap">
+                      {tx.date ? formatDate(tx.date) : "—"}
+                    </td>
+                    <td className="py-2 text-zinc-200 max-w-[320px] truncate">{tx.description}</td>
+                    <td className="py-2 text-zinc-400">{tx.category}</td>
+                    <td className="py-2 text-right">
+                      <div className="font-mono text-zinc-100">{formatCurrency(tx.amount)}</div>
+                      <div className="text-xs text-zinc-500">{note}</div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="bg-[#141420] border border-[#27272a] rounded-xl p-5 overflow-x-auto">
+        <h2 className="text-lg font-semibold mb-4">New Merchants</h2>
+        {newMerchants.length === 0 ? (
+          <p className="text-zinc-500 text-sm">No first-time merchants detected this month.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-zinc-500 text-left border-b border-zinc-800">
+                <th className="pb-2 font-medium">Merchant</th>
+                <th className="pb-2 font-medium text-right">Amount</th>
+                <th className="pb-2 font-medium text-right">Note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {newMerchants.map((m, i) => (
+                <tr key={`${m.merchant}-${i}`} className="border-b border-zinc-800/40 hover:bg-zinc-800/20">
+                  <td className="py-2 text-zinc-200">{m.merchant}</td>
+                  <td className="py-2 text-right font-mono text-zinc-100">{formatCurrency(m.total)}</td>
+                  <td className="py-2 text-right text-orange-400 font-semibold">🆕 First time</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/finance/Nav.tsx
+++ b/web/src/components/finance/Nav.tsx
@@ -25,6 +25,7 @@ const sections = [
     links: [
       { href: "/finance/insights", label: "Insights", icon: "💡" },
       { href: "/finance/velocity", label: "Spending Velocity", icon: "🔥" },
+      { href: "/finance/anomalies", label: "Anomalies", icon: "🚨" },
       { href: "/finance/heatmap", label: "Spending Heatmap", icon: "🗓️" },
       { href: "/finance/restaurants", label: "Restaurants", icon: "🍽️" },
       { href: "/finance/delivery-vs-dinein", label: "Delivery vs Dining", icon: "🚗" },

--- a/web/src/lib/finance-queries.ts
+++ b/web/src/lib/finance-queries.ts
@@ -658,6 +658,145 @@ export async function getSpendingVelocity() {
   };
 }
 
+// ─── Spending Anomaly Detector ────────────────────────────────────────────
+export async function getSpendingAnomalies() {
+  const db = await getDb();
+  const now = new Date();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  const priorThreeStart = new Date(now.getFullYear(), now.getMonth() - 3, 1);
+
+  const UNKNOWN_CATEGORY_AVG_THRESHOLD = 200;
+  const NEW_MERCHANT_MIN_TOTAL = 50;
+
+  const [
+    thisMonthByCategory,
+    priorThreeByCategory,
+    priorThreeAvgTxns,
+    thisMonthTransactions,
+    thisMonthMerchantTotals,
+    merchantFirstSeen,
+  ] = await Promise.all([
+    db.collection("transactions").aggregate([
+      { $match: { date: { $gte: monthStart, $lt: monthEnd }, amount: { $lt: 0 }, category: { $nin: ["Transfer", null, ""] } } },
+      { $group: { _id: "$category", total: { $sum: { $abs: "$amount" } } } },
+    ]).toArray(),
+    db.collection("transactions").aggregate([
+      { $match: { date: { $gte: priorThreeStart, $lt: monthStart }, amount: { $lt: 0 }, category: { $nin: ["Transfer", null, ""] } } },
+      { $group: { _id: "$category", total: { $sum: { $abs: "$amount" } } } },
+    ]).toArray(),
+    db.collection("transactions").aggregate([
+      { $match: { date: { $gte: priorThreeStart, $lt: monthStart }, amount: { $lt: 0 }, category: { $nin: ["Transfer", null, ""] } } },
+      { $group: { _id: "$category", avgAmount: { $avg: { $abs: "$amount" } } } },
+    ]).toArray(),
+    db.collection("transactions").find(
+      {
+        date: { $gte: monthStart, $lt: monthEnd },
+        amount: { $lt: 0 },
+        category: { $nin: ["Transfer", null, ""] },
+        description: { $nin: [null, ""] },
+      },
+      { projection: { date: 1, description: 1, category: 1, amount: 1 } }
+    ).toArray(),
+    db.collection("transactions").aggregate([
+      {
+        $match: {
+          date: { $gte: monthStart, $lt: monthEnd },
+          amount: { $lt: 0 },
+          category: { $nin: ["Transfer", null, ""] },
+          description: { $nin: [null, ""] },
+        },
+      },
+      { $group: { _id: "$description", total: { $sum: { $abs: "$amount" } }, count: { $sum: 1 } } },
+      { $sort: { total: -1 } },
+    ]).toArray(),
+    db.collection("transactions").aggregate([
+      { $match: { amount: { $lt: 0 }, category: { $nin: ["Transfer", null, ""] }, description: { $nin: [null, ""] } } },
+      { $group: { _id: "$description", firstSeen: { $min: "$date" } } },
+    ]).toArray(),
+  ]);
+
+  const priorTotals = new Map<string, number>();
+  (priorThreeByCategory as Array<{ _id: string; total: number }>).forEach((row) => {
+    priorTotals.set(row._id, row.total / 3);
+  });
+
+  const categorySpikes = (thisMonthByCategory as Array<{ _id: string; total: number }>)
+    .map((row) => {
+      const avgPrior3 = priorTotals.get(row._id) || 0;
+      const ratio = avgPrior3 > 0 ? row.total / avgPrior3 : 0;
+      return {
+        category: row._id,
+        thisMonth: row.total,
+        avgPrior3,
+        ratio,
+        delta: row.total - avgPrior3,
+      };
+    })
+    .filter((row) => row.ratio >= 1.4)
+    .sort((a, b) => b.ratio - a.ratio)
+    .slice(0, 10);
+
+  const categoryAvgTxnMap = new Map<string, number>();
+  (priorThreeAvgTxns as Array<{ _id: string; avgAmount: number }>).forEach((row) => {
+    categoryAvgTxnMap.set(row._id, row.avgAmount || 0);
+  });
+
+  const largeTransactions = (thisMonthTransactions as Array<{ amount?: number; description?: string; category?: string; date?: Date }>)
+    .map((t) => {
+      const amountAbs = Math.abs(t.amount || 0);
+      const avgAmount = t.category ? (categoryAvgTxnMap.get(t.category) || 0) : 0;
+      const ratio = avgAmount > 0 ? amountAbs / avgAmount : 0;
+      return {
+        date: t.date,
+        description: t.description || "",
+        category: t.category || "Uncategorized",
+        amount: amountAbs,
+        avgCategoryAmount: avgAmount,
+        ratio,
+      };
+    })
+    .filter((t) => (t.avgCategoryAmount > 0 ? t.ratio > 3 : t.amount > UNKNOWN_CATEGORY_AVG_THRESHOLD))
+    .sort((a, b) => (b.ratio || 0) - (a.ratio || 0) || b.amount - a.amount)
+    .slice(0, 15);
+
+  const firstSeenMap = new Map<string, Date>();
+  (merchantFirstSeen as Array<{ _id: string; firstSeen: Date }>).forEach((row) => {
+    if (row._id) firstSeenMap.set(row._id, row.firstSeen);
+  });
+
+  const newMerchants = (thisMonthMerchantTotals as Array<{ _id: string; total: number }>)
+    .map((row) => {
+      const firstSeen = firstSeenMap.get(row._id);
+      return {
+        merchant: row._id,
+        total: row.total,
+        firstSeen,
+      };
+    })
+    .filter((row) => {
+      if (!row.firstSeen) return false;
+      return row.firstSeen >= monthStart && row.firstSeen < monthEnd && row.total > NEW_MERCHANT_MIN_TOTAL;
+    })
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 10);
+
+  return {
+    categorySpikes,
+    largeTransactions,
+    newMerchants,
+    summary: {
+      totalCategorySpikes: categorySpikes.length,
+      totalLargeTransactions: largeTransactions.length,
+      totalNewMerchants: newMerchants.length,
+    },
+    thresholds: {
+      unknownCategoryAvg: UNKNOWN_CATEGORY_AVG_THRESHOLD,
+      newMerchantMinTotal: NEW_MERCHANT_MIN_TOTAL,
+    },
+  };
+}
+
 // ─── Budget History (6-month budget vs actual) ─────────────────────────────
 export async function getBudgetHistory(months = 6) {
   const db = await getDb();


### PR DESCRIPTION
Closes #18

## What's in this PR

- **getSpendingAnomalies()** — 6-query MongoDB pipeline that detects:
  - Category spikes: this month ≥ 1.4x the prior 3-month average
  - Large transactions: single charges > 3x the category's average transaction amount (or > if no history)
  - New merchants: first-time merchants this month with total > 
- **New page** /finance/anomalies with:
  - 3 stat cards: Category Spikes / Large Transactions / New Merchants
  - Category Spikes table with color-coded ratio badges (red ≥2x, yellow ≥1.5x, orange ≥1.4x)
  - Large Transactions table with Nx avg annotation
  - New Merchants list with 🆕 first-time badge
  - Empty state for each section
- **Nav**: 🚨 Anomalies added to Reports section