### PR TITLE
Finance: Income Breakdown /finance/income

### DIFF
--- a/web/src/app/finance/income/page.tsx
+++ b/web/src/app/finance/income/page.tsx
@@ -1,0 +1,172 @@
+import { getIncomeBreakdown } from "@/lib/finance-queries";
+import { formatCurrency, formatDate } from "@/lib/utils";
+import { Card } from "@/components/finance/Card";
+import { SpendBarChart } from "@/components/finance/Charts";
+
+export const dynamic = "force-dynamic";
+
+type IncomeMonth = {
+  month: string;
+  total: number;
+  count: number;
+};
+
+type IncomeSource = {
+  description: string;
+  total: number;
+  count: number;
+  avgAmount: number;
+  lastDate: Date | string;
+};
+
+type IncomeStats = {
+  thisMonthTotal: number;
+  lastMonthTotal: number;
+  avgMonthly: number;
+  totalYTD: number;
+  momChange: number;
+};
+
+type IncomeTransaction = {
+  date: Date | string;
+  description: string;
+  amount: number;
+};
+
+type IncomeBreakdown = {
+  monthlyIncome: IncomeMonth[];
+  incomeSources: IncomeSource[];
+  stats: IncomeStats;
+  largestTransactions: IncomeTransaction[];
+};
+
+function formatMonthLabel(monthKey: string) {
+  const [year, month] = monthKey.split("-").map(Number);
+  const date = new Date(year, month - 1, 1);
+  return date.toLocaleDateString("en-US", { month: "short", year: "2-digit" });
+}
+
+export default async function IncomePage() {
+  const { monthlyIncome, incomeSources, stats, largestTransactions } = await getIncomeBreakdown() as unknown as IncomeBreakdown;
+
+  const chartData = monthlyIncome.map((m) => ({
+    label: formatMonthLabel(m.month),
+    total: m.total,
+  }));
+
+  const momPct = stats.momChange * 100;
+  const momLabel = `${momPct >= 0 ? "+" : ""}${momPct.toFixed(1)}%`;
+  const momBadgeClass = stats.momChange >= 0
+    ? "text-emerald-400 border-emerald-500/30 bg-emerald-500/10"
+    : "text-red-400 border-red-500/30 bg-red-500/10";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Income</h1>
+        <p className="text-zinc-400 text-sm mt-1">Income sources and trends</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Card
+          title="This Month"
+          value={formatCurrency(stats.thisMonthTotal)}
+          subtitle="Current month income"
+          className="border-emerald-500/20"
+        />
+        <div className="bg-[#141420] border border-[#27272a] rounded-xl p-5">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-zinc-400">Last Month</p>
+            <span className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${momBadgeClass}`}>
+              {momLabel}
+            </span>
+          </div>
+          <p className="text-2xl font-bold tracking-tight mt-1">{formatCurrency(stats.lastMonthTotal)}</p>
+          <p className="text-xs text-zinc-500 mt-1">MoM change vs this month</p>
+        </div>
+        <Card
+          title="Avg Monthly (12mo)"
+          value={formatCurrency(stats.avgMonthly)}
+          subtitle="Rolling 12-month avg"
+        />
+        <Card
+          title="YTD Total"
+          value={formatCurrency(stats.totalYTD)}
+          subtitle="Since Jan 1"
+        />
+      </div>
+
+      <div className="bg-[#141420] border border-[#27272a] rounded-xl p-5">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold">Monthly Income</h2>
+          <span className="text-xs text-zinc-500">Last 12 months</span>
+        </div>
+        <SpendBarChart data={chartData} />
+      </div>
+
+      <div className="bg-[#141420] border border-[#27272a] rounded-xl p-5">
+        <h2 className="text-lg font-semibold mb-4">Income Sources</h2>
+        {incomeSources.length === 0 ? (
+          <p className="text-sm text-zinc-500">No income sources found.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-zinc-500 text-left border-b border-zinc-800">
+                  <th className="pb-2 font-medium">Description</th>
+                  <th className="pb-2 font-medium text-right">Avg Amount</th>
+                  <th className="pb-2 font-medium text-right">Times</th>
+                  <th className="pb-2 font-medium text-right">Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {incomeSources.map((source) => (
+                  <tr key={source.description} className="border-b border-zinc-800/40 hover:bg-zinc-800/20">
+                    <td className="py-2 text-zinc-200">{source.description}</td>
+                    <td className="py-2 text-right font-mono text-emerald-400">
+                      {formatCurrency(source.avgAmount)}
+                    </td>
+                    <td className="py-2 text-right font-mono text-zinc-300">{source.count}</td>
+                    <td className="py-2 text-right font-mono font-semibold text-zinc-100">
+                      {formatCurrency(source.total)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="bg-[#141420] border border-[#27272a] rounded-xl p-5">
+        <h2 className="text-lg font-semibold mb-4">Largest Single Transactions</h2>
+        {largestTransactions.length === 0 ? (
+          <p className="text-sm text-zinc-500">No income transactions found.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-zinc-500 text-left border-b border-zinc-800">
+                  <th className="pb-2 font-medium">Date</th>
+                  <th className="pb-2 font-medium">Description</th>
+                  <th className="pb-2 font-medium text-right">Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {largestTransactions.map((tx, i) => (
+                  <tr key={`${tx.description}-${i}`} className="border-b border-zinc-800/40 hover:bg-zinc-800/20">
+                    <td className="py-2 text-zinc-400">{formatDate(tx.date)}</td>
+                    <td className="py-2 text-zinc-200">{tx.description}</td>
+                    <td className="py-2 text-right font-mono font-semibold text-emerald-400">
+                      {formatCurrency(tx.amount)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/finance/Charts.tsx
+++ b/web/src/components/finance/Charts.tsx
@@ -11,6 +11,7 @@ type MonthlyBarDatum = { _id: string; income: number; expenses: number };
 type CategoryDatum = { _id: string; total: number };
 type NetWorthDatum = { month: string; net: number };
 type DowDatum = { _id: number | string; total: number; count: number };
+type SpendBarDatum = { label: string; total: number };
 
 export function MonthlyBarChart({ data }: { data: MonthlyBarDatum[] }) {
   return (
@@ -70,6 +71,19 @@ export function DowChart({ data }: { data: DowDatum[] }) {
         <YAxis stroke="#71717a" fontSize={12} tickFormatter={(v) => `$${v.toFixed(0)}`} />
         <Tooltip contentStyle={tooltipStyle} formatter={(v: unknown) => formatCurrency(Number(v))} />
         <Bar dataKey="avg" name="Avg Spend" fill="#8b5cf6" radius={[4,4,0,0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function SpendBarChart({ data }: { data: SpendBarDatum[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data}>
+        <XAxis dataKey="label" stroke="#71717a" fontSize={12} />
+        <YAxis stroke="#71717a" fontSize={12} tickFormatter={(v) => `$${(v / 1000).toFixed(0)}k`} />
+        <Tooltip contentStyle={tooltipStyle} formatter={(v: unknown) => formatCurrency(Number(v))} />
+        <Bar dataKey="total" name="Total" fill="#10b981" radius={[4,4,0,0]} />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/web/src/components/finance/Nav.tsx
+++ b/web/src/components/finance/Nav.tsx
@@ -10,6 +10,7 @@ const sections = [
       { href: "/finance", label: "Dashboard", icon: "📊" },
       { href: "/finance/transactions", label: "Transactions", icon: "💳" },
       { href: "/finance/cashflow", label: "Cash Flow", icon: "📈" },
+      { href: "/finance/income", label: "Income", icon: "💵" },
     ],
   },
   {

--- a/web/src/lib/finance-queries.ts
+++ b/web/src/lib/finance-queries.ts
@@ -567,6 +567,75 @@ export async function getCashFlowProjection() {
   return { accounts, monthlyData, recurringPatterns, incomeSources };
 }
 
+// ─── Income Breakdown ──────────────────────────────────────────────────────
+export async function getIncomeBreakdown() {
+  const db = await getDb();
+  const now = new Date();
+
+  const monthKey = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  const start = new Date(now.getFullYear(), now.getMonth() - 11, 1);
+  const yearStart = new Date(now.getFullYear(), 0, 1);
+
+  const [monthlyRows, incomeSources, ytdRows, largestTransactions] = await Promise.all([
+    db.collection("transactions").aggregate([
+      { $match: { date: { $gte: start }, amount: { $gt: 0 }, category: { $ne: "Transfer" } } },
+      { $addFields: { monthKey: { $dateToString: { format: "%Y-%m", date: "$date" } } } },
+      { $group: { _id: "$monthKey", total: { $sum: "$amount" }, count: { $sum: 1 } } },
+      { $sort: { _id: 1 } },
+    ]).toArray(),
+    db.collection("transactions").aggregate([
+      { $match: { amount: { $gt: 0 }, category: { $ne: "Transfer" } } },
+      {
+        $group: {
+          _id: "$description",
+          total: { $sum: "$amount" },
+          count: { $sum: 1 },
+          avgAmount: { $avg: "$amount" },
+          lastDate: { $max: "$date" },
+        },
+      },
+      { $project: { _id: 0, description: "$_id", total: 1, count: 1, avgAmount: 1, lastDate: 1 } },
+      { $sort: { total: -1 } },
+      { $limit: 20 },
+    ]).toArray(),
+    db.collection("transactions").aggregate([
+      { $match: { date: { $gte: yearStart, $lt: now }, amount: { $gt: 0 }, category: { $ne: "Transfer" } } },
+      { $group: { _id: null, total: { $sum: "$amount" } } },
+    ]).toArray(),
+    db.collection("transactions")
+      .find({ amount: { $gt: 0 }, category: { $ne: "Transfer" } })
+      .sort({ amount: -1 })
+      .limit(10)
+      .toArray(),
+  ]);
+
+  const monthSlots = Array.from({ length: 12 }, (_, i) => {
+    const date = new Date(now.getFullYear(), now.getMonth() - 11 + i, 1);
+    return { key: monthKey(date) };
+  });
+  const monthMap = new Map((monthlyRows as Array<{ _id: string; total: number; count: number }>).map((r) => [r._id, r]));
+  const monthlyIncome = monthSlots.map((slot) => ({
+    month: slot.key,
+    total: monthMap.get(slot.key)?.total || 0,
+    count: monthMap.get(slot.key)?.count || 0,
+  }));
+
+  const thisMonthKey = monthKey(now);
+  const lastMonthKey = monthKey(new Date(now.getFullYear(), now.getMonth() - 1, 1));
+  const thisMonthTotal = monthMap.get(thisMonthKey)?.total || 0;
+  const lastMonthTotal = monthMap.get(lastMonthKey)?.total || 0;
+  const avgMonthly = monthlyIncome.reduce((s, m) => s + m.total, 0) / monthlyIncome.length;
+  const totalYTD = (ytdRows as Array<{ total: number }>)[0]?.total || 0;
+  const momChange = lastMonthTotal > 0 ? (thisMonthTotal - lastMonthTotal) / lastMonthTotal : 0;
+
+  return {
+    monthlyIncome,
+    incomeSources,
+    stats: { thisMonthTotal, lastMonthTotal, avgMonthly, totalYTD, momChange },
+    largestTransactions,
+  };
+}
+
 // ─── Savings Rate Timeline ─────────────────────────────────────────────────
 export async function getMonthlySavingsRate(months = 12) {
   const db = await getDb();


### PR DESCRIPTION
Closes #19

## What's in this PR

- **getIncomeBreakdown()** query returns:
  - Monthly income for last 12 months (with 0-fill for missing months)
  - Top 20 income sources by total (description, avg amount, count, total)
  - Stats: this month, last month, 12-month avg, YTD total, MoM % change
  - Top 10 largest single income transactions
- **New page** /finance/income:
  - This Month card (green border)
  - Last Month card with MoM badge (green +% or red -%)
  - Avg Monthly (12mo) card
  - YTD Total card
  - Monthly income bar chart (emerald green bars, 12 months)
  - Income Sources table: description, avg amount, times, total
  - Largest Single Transactions table
- **Nav**: 💵 Income added to Overview section (after Cash Flow)
- **SpendBarChart** component added to Charts.tsx (reusable, emerald fill)